### PR TITLE
Parse code blocks metadata

### DIFF
--- a/doc/dune
+++ b/doc/dune
@@ -6,25 +6,38 @@
 
 (rule
  (target odoc_parser__Loc.odoc)
- (deps (:cmti ../src/.odoc_parser.objs/byte/odoc_parser__Loc.cmti) odoc_parser__.odoc)
+ (deps
+  (:cmti ../src/.odoc_parser.objs/byte/odoc_parser__Loc.cmti)
+  odoc_parser__.odoc)
  (action
   (run odoc compile -o %{target} -I . %{cmti})))
 
 (rule
  (target odoc_parser__Warning.odoc)
- (deps (:cmti ../src/.odoc_parser.objs/byte/odoc_parser__Warning.cmt) odoc_parser__.odoc odoc_parser__Loc.odoc)
+ (deps
+  (:cmti ../src/.odoc_parser.objs/byte/odoc_parser__Warning.cmt)
+  odoc_parser__.odoc
+  odoc_parser__Loc.odoc)
  (action
   (run odoc compile -o %{target} -I . %{cmti})))
 
 (rule
  (target odoc_parser__Ast.odoc)
- (deps (:cmti ../src/.odoc_parser.objs/byte/odoc_parser__Ast.cmt) odoc_parser__.odoc odoc_parser__Loc.odoc)
+ (deps
+  (:cmti ../src/.odoc_parser.objs/byte/odoc_parser__Ast.cmt)
+  odoc_parser__.odoc
+  odoc_parser__Loc.odoc)
  (action
   (run odoc compile -o %{target} -I . %{cmti})))
 
 (rule
  (target odoc_parser.odoc)
- (deps (:cmti ../src/.odoc_parser.objs/byte/odoc_parser.cmti) odoc_parser__.odoc odoc_parser__Loc.odoc odoc_parser__Warning.odoc odoc_parser__Ast.odoc)
+ (deps
+  (:cmti ../src/.odoc_parser.objs/byte/odoc_parser.cmti)
+  odoc_parser__.odoc
+  odoc_parser__Loc.odoc
+  odoc_parser__Warning.odoc
+  odoc_parser__Ast.odoc)
  (action
   (run odoc compile -o %{target} -I . %{cmti})))
 
@@ -43,21 +56,25 @@
 (rule
  (alias docgen)
  (target odoc_parser.odocl)
- (deps (:odoc odoc_parser.odoc))
+ (deps
+  (:odoc odoc_parser.odoc))
  (action
   (run odoc link -o %{target} -I . %{odoc})))
 
 (rule
  (alias docgen)
  (target page-index.odocl)
- (deps odoc_parser.odocl page-contributing.odoc (:odoc page-index.odoc))
+ (deps
+  odoc_parser.odocl
+  page-contributing.odoc
+  (:odoc page-index.odoc))
  (action
   (run odoc link -o %{target} -I . %{odoc})))
 
 (rule
  (alias docgen)
  (target page-contributing.odocl)
- (deps (:odoc page-contributing.odoc))
+ (deps
+  (:odoc page-contributing.odoc))
  (action
   (run odoc link -o %{target} -I . %{odoc})))
-

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -31,7 +31,10 @@ type inline_element =
 
 type nestable_block_element =
   [ `Paragraph of inline_element with_location list
-  | `Code_block of string with_location option * string with_location
+  | `Code_block of
+    (string with_location * string with_location option) option
+    * string with_location
+    (** [(language tag * metadata option) option * content] *)
   | `Verbatim of string
   | `Modules of string with_location list
   | `List of

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -34,7 +34,7 @@ type nestable_block_element =
   | `Code_block of
     (string with_location * string with_location option) option
     * string with_location
-    (** [(language tag * metadata option) option * content] *)
+    (* [(language tag * metadata option) option * content] *)
   | `Verbatim of string
   | `Modules of string with_location list
   | `List of

--- a/src/parse_error.ml
+++ b/src/parse_error.ml
@@ -67,6 +67,10 @@ let no_language_tag_in_meta : Loc.span -> Warning.t =
   Warning.make ~suggestion:"try '{[ ... ]}' or '{@ocaml[ ... ]}'."
     "'{@' should be followed by a language tag."
 
+let language_tag_invalid_char lang_tag : char -> Loc.span -> Warning.t =
+  let suggestion = "try '{@" ^ lang_tag ^ "[ ... ]}'." in
+  Warning.make ~suggestion "Invalid character '%c' in language tag."
+
 let truncated_code_block_meta : Loc.span -> Warning.t =
   Warning.make ~suggestion:"try '{@ocaml[ ... ]}'." "Missing end of code block."
 

--- a/src/parse_error.ml
+++ b/src/parse_error.ml
@@ -62,3 +62,13 @@ let unpaired_right_brace : Loc.span -> Warning.t =
 
 let unpaired_right_bracket : Loc.span -> Warning.t =
   Warning.make ~suggestion:"try '\\]'." "Unpaired ']' (end of code)."
+
+let no_language_tag_in_meta : Loc.span -> Warning.t =
+  Warning.make ~suggestion:"try '{[ ... ]}' or '{@ocaml[ ... ]}'."
+    "'{@' should be followed by a language tag."
+
+let truncated_code_block_meta : Loc.span -> Warning.t =
+  Warning.make ~suggestion:"try '{@ocaml[ ... ]}'." "Missing end of code block."
+
+let truncated_code_block : Loc.span -> Warning.t =
+  Warning.make ~suggestion:"add ']}'." "Missing end of code block."

--- a/src/token.ml
+++ b/src/token.ml
@@ -62,7 +62,8 @@ type t =
   | `Begin_link_with_replacement_text of string
   | (* Leaf block element markup. *)
     `Code_block of
-    string Loc.with_location option * string Loc.with_location
+    (string Loc.with_location * string Loc.with_location option) option
+    * string Loc.with_location
   | `Verbatim of string
   | `Modules of string
   | (* List markup. *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -2640,7 +2640,8 @@ let%expect_test _ =
 
     let newlines_after_langtag =
       test "{@ocaml\n[ code ]}";
-      [%expect{|
+      [%expect
+        {|
         ((output
           (((f.ml (1 0) (2 9))
             (code_block (((f.ml (1 2) (1 7)) ocaml) ()) ((f.ml (2 1) (2 7)) "code ")))))
@@ -2648,7 +2649,8 @@ let%expect_test _ =
 
     let newlines_after_meta =
       test "{@ocaml kind=toplevel\n[ code ]}";
-      [%expect{|
+      [%expect
+        {|
         ((output
           (((f.ml (1 0) (2 9))
             (code_block
@@ -2658,7 +2660,8 @@ let%expect_test _ =
 
     let newlines_inside_meta =
       test "{@ocaml kind=toplevel\nenv=e1[ code ]}";
-      [%expect{|
+      [%expect
+        {|
         ((output
           (((f.ml (1 0) (2 15))
             (code_block
@@ -2670,7 +2673,8 @@ let%expect_test _ =
 
     let newlines_between_meta =
       test "{@ocaml\nkind=toplevel[ code ]}";
-      [%expect{|
+      [%expect
+        {|
         ((output
           (((f.ml (1 0) (2 22))
             (code_block
@@ -2680,7 +2684,8 @@ let%expect_test _ =
 
     let langtag_non_word =
       test "{@ocaml,top[ code ]}";
-      [%expect{|
+      [%expect
+        {|
         ((output
           (((f.ml (1 0) (1 20))
             (code_block (((f.ml (1 2) (1 7)) ocaml) ())

--- a/test/test.ml
+++ b/test/test.ml
@@ -2677,6 +2677,18 @@ let%expect_test _ =
              (((f.ml (1 2) (1 7)) ocaml) (((f.ml (2 0) (2 13)) kind=toplevel)))
              ((f.ml (2 14) (2 20)) "code ")))))
          (warnings ())) |}]
+
+    let langtag_non_word =
+      test "{@ocaml,top[ code ]}";
+      [%expect{|
+        ((output
+          (((f.ml (1 0) (1 20))
+            (code_block (((f.ml (1 2) (1 7)) ocaml) ())
+             ((f.ml (1 8) (1 18)) "top[ code ")))))
+         (warnings
+          ( "File \"f.ml\", line 1, characters 0-8:\
+           \nInvalid character ',' in language tag.\
+           \nSuggestion: try '{@ocaml[ ... ]}'."))) |}]
   end in
   ()
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -2637,6 +2637,46 @@ let%expect_test _ =
            \nSuggestion: try '{@ocaml[ ... ]}'."
             "File \"f.ml\", line 1, characters 0-5:\
            \n'{[...]}' (code block) should not be empty."))) |}]
+
+    let newlines_after_langtag =
+      test "{@ocaml\n[ code ]}";
+      [%expect{|
+        ((output
+          (((f.ml (1 0) (2 9))
+            (code_block (((f.ml (1 2) (1 7)) ocaml) ()) ((f.ml (2 1) (2 7)) "code ")))))
+         (warnings ())) |}]
+
+    let newlines_after_meta =
+      test "{@ocaml kind=toplevel\n[ code ]}";
+      [%expect{|
+        ((output
+          (((f.ml (1 0) (2 9))
+            (code_block
+             (((f.ml (1 2) (1 7)) ocaml) (((f.ml (1 8) (2 0)) "kind=toplevel\n")))
+             ((f.ml (2 1) (2 7)) "code ")))))
+         (warnings ())) |}]
+
+    let newlines_inside_meta =
+      test "{@ocaml kind=toplevel\nenv=e1[ code ]}";
+      [%expect{|
+        ((output
+          (((f.ml (1 0) (2 15))
+            (code_block
+             (((f.ml (1 2) (1 7)) ocaml)
+              (((f.ml (1 8) (2 6))  "kind=toplevel\
+                                   \nenv=e1")))
+             ((f.ml (2 7) (2 13)) "code ")))))
+         (warnings ())) |}]
+
+    let newlines_between_meta =
+      test "{@ocaml\nkind=toplevel[ code ]}";
+      [%expect{|
+        ((output
+          (((f.ml (1 0) (2 22))
+            (code_block
+             (((f.ml (1 2) (1 7)) ocaml) (((f.ml (2 0) (2 13)) kind=toplevel)))
+             ((f.ml (2 14) (2 20)) "code ")))))
+         (warnings ())) |}]
   end in
   ()
 


### PR DESCRIPTION
The first commit parses the "metadata" string that can be attached to code blocks into two fields: the language tag and the arbitrary metadata string. The AST node is changed to

```ocaml
  | `Code_block of
    (string with_location * string with_location option) option
    * string with_location
```

The second field is parsed as before, it takes any characters until the first `[`, there's no escaping and it doesn't strip trailing whitespaces.
The first field is parsed as a word (a new definition of "word"). It is mandatory when using the `{@lang metadata[ ... ]}` syntax.

The second commit allows newlines between the two fields. Newlines were already allowed but were treated as part of the second field.

The parsing of code blocks still has rough edges (eg. lack of escaping, including the trailing whitespaces) but this shouldn't make it worse.
