### PR TITLE
Depend on camlp-streams for OCaml 5.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -20,5 +20,6 @@ understood by ocamldoc.")
   (ocaml (>= 4.02.0))
   astring
   result
+  camlp-streams
   (ppx_expect :with-test)))
 

--- a/odoc-parser.opam
+++ b/odoc-parser.opam
@@ -20,6 +20,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "astring"
   "result"
+  "camlp-streams"
   "ppx_expect" {with-test}
   ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
 ]

--- a/odoc-parser.opam.template
+++ b/odoc-parser.opam.template
@@ -6,6 +6,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "astring"
   "result"
+  "camlp-streams"
   "ppx_expect" {with-test}
   ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
 ]

--- a/src/dune
+++ b/src/dune
@@ -5,4 +5,4 @@
  (public_name odoc-parser)
  (instrumentation
   (backend bisect_ppx))
- (libraries astring result))
+ (libraries astring result camlp-streams))


### PR DESCRIPTION
`Stdlib.Stream` is gone in 5.0.