### PR TITLE
Check reference content for open curly brackets.

### DIFF
--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -338,8 +338,16 @@ rule token input = parse
     { emit input (`Modules modules) }
 
   | (reference_start as start) ([^ '}']* as target) '}'
-    { emit input (reference_token start target) }
-
+    { 
+      let token = (reference_token start target) in
+      if String.contains target '{' then
+        warning
+          input
+          ~start_offset:(Lexing.lexeme_start lexbuf)
+          (Parse_error.not_allowed
+            ~what:(Token.describe (`Word {|{|}))
+            ~in_what:(Token.describe token));
+      emit input token}
   | "{["
     { code_block (Lexing.lexeme_start lexbuf) None input lexbuf }
 

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -345,9 +345,9 @@ rule token input = parse
           input
           ~start_offset:(Lexing.lexeme_start lexbuf)
           (Parse_error.not_allowed
-            ~what:(Token.describe (`Word {|{|}))
+            ~what:(Token.describe (`Word "{"))
             ~in_what:(Token.describe token));
-      emit input token}
+      emit input token }
   | "{["
     { code_block (Lexing.lexeme_start lexbuf) None input lexbuf }
 


### PR DESCRIPTION
This docstring :
```
(** {! reference {} *)
```
Now gets you the following warning :
```
File "...", line ..., characters ...-... :
'{' is not allowed in '{!...}' (cross-reference).
```
It used to be accepted without any warning.