### PR TITLE
Reference syntax

### DIFF
--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -271,8 +271,61 @@ let raw_markup_target =
 let language_tag_char =
   ['a'-'z' 'A'-'Z' '0'-'9' '_' '-' ]
 
+rule reference_paren_content input start depth buffer = parse 
+  | '('
+    {
+      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+       reference_paren_content input start (depth + 1) buffer lexbuf }
+  | ')'
+    { 
+      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      if depth = 0 then
+        ()
+      else
+        ( reference_paren_content input start (depth  - 1) buffer lexbuf ) }
+  | eof 
+    { warning
+        input
+        ~start_offset:(Lexing.lexeme_end lexbuf)
+        (Parse_error.not_allowed
+          ~what:(Token.describe `End)
+          ~in_what:(Token.describe (reference_token start ""))) 
+    }
+  | _
+    { 
+      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      reference_paren_content input start depth buffer lexbuf }
 
-rule token input = parse
+and reference_content input start buffer = parse
+  | '}' 
+    {
+      Buffer.contents buffer
+    }
+  | '('
+    {
+      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      ((reference_paren_content input start 0 buffer lexbuf)) ;
+      reference_content input start buffer lexbuf
+    }
+  | '"' [^ '"']* '"'
+    {
+      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      reference_content input start buffer lexbuf
+    }
+  | eof 
+    { warning
+        input
+        ~start_offset:(Lexing.lexeme_end lexbuf)
+        (Parse_error.not_allowed
+          ~what:(Token.describe `End)
+          ~in_what:(Token.describe (reference_token start "")));
+        Buffer.contents buffer }
+  | _
+    { 
+      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      reference_content input start buffer lexbuf }
+
+and token input = parse
   | horizontal_space* eof
     { emit input `End }
 
@@ -337,17 +390,13 @@ rule token input = parse
   | "{!modules:" ([^ '}']* as modules) '}'
     { emit input (`Modules modules) }
 
-  | (reference_start as start) ([^ '}']* as target) '}'
+  | (reference_start as start)
     { 
+      let start_offset = Lexing.lexeme_start lexbuf in
+      let target = reference_content input start (Buffer.create 16) lexbuf in
       let token = (reference_token start target) in
-      if String.contains target '{' then
-        warning
-          input
-          ~start_offset:(Lexing.lexeme_start lexbuf)
-          (Parse_error.not_allowed
-            ~what:(Token.describe (`Word "{"))
-            ~in_what:(Token.describe token));
-      emit input token }
+      emit ~start_offset input token }
+
   | "{["
     { code_block (Lexing.lexeme_start lexbuf) None input lexbuf }
 
@@ -457,9 +506,6 @@ rule token input = parse
 
   | "@closed"
     { emit input (`Tag `Closed) }
-
-
-
   | '{'
     { try bad_markup_recovery (Lexing.lexeme_start lexbuf) input lexbuf
       with Failure _ ->
@@ -509,17 +555,6 @@ rule token input = parse
           ~what:(Token.describe `End)
           ~in_what:(Token.describe (`Modules "")));
       emit input (`Modules modules) }
-
-  | (reference_start as start) ([^ '}']* as target) eof
-    { warning
-        input
-        ~start_offset:(Lexing.lexeme_end lexbuf)
-        (Parse_error.not_allowed
-          ~what:(Token.describe `End)
-          ~in_what:(Token.describe (reference_token start "")));
-      emit input (reference_token start target) }
-
-
 
 and code_span buffer nesting_level start_offset input = parse
   | ']'

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -239,6 +239,9 @@ let heading_level input level =
   end;
   int_of_string level
 
+let buffer_add_lexeme buffer lexbuf =
+  Buffer.add_string buffer (Lexing.lexeme lexbuf)
+
 }
 
 
@@ -274,24 +277,24 @@ let language_tag_char =
 rule reference_paren_content input start depth_paren depth_curly buffer = parse
   | '('
     {
-      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      buffer_add_lexeme buffer lexbuf ;
        reference_paren_content input start (depth_paren + 1) depth_curly buffer
         lexbuf }
   | '{'
     {
-      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      buffer_add_lexeme buffer lexbuf ;
        reference_paren_content input start depth_paren (depth_curly + 1) buffer
         lexbuf }
   | ')'
     {
-      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      buffer_add_lexeme buffer lexbuf ;
       if depth_paren = 0 then ()
       else
         ( reference_paren_content input start (depth_paren - 1) depth_curly
             buffer lexbuf ) }
   | '}'
     {
-      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      buffer_add_lexeme buffer lexbuf ;
       if depth_curly = 0 then
         warning
           input
@@ -314,7 +317,7 @@ rule reference_paren_content input start depth_paren depth_curly buffer = parse
     }
   | _
     {
-      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      buffer_add_lexeme buffer lexbuf ;
       reference_paren_content input start depth_paren depth_curly buffer lexbuf }
 
 and reference_content input start buffer = parse
@@ -324,13 +327,13 @@ and reference_content input start buffer = parse
     }
   | '('
     {
-      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      buffer_add_lexeme buffer lexbuf ;
       ((reference_paren_content input start 0 0 buffer lexbuf)) ;
       reference_content input start buffer lexbuf
     }
   | '"' [^ '"']* '"'
     {
-      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      buffer_add_lexeme buffer lexbuf ;
       reference_content input start buffer lexbuf
     }
   | eof
@@ -343,7 +346,7 @@ and reference_content input start buffer = parse
         Buffer.contents buffer }
   | _
     {
-      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      buffer_add_lexeme buffer lexbuf ;
       reference_content input start buffer lexbuf }
 
 and token input = parse

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -338,8 +338,16 @@ rule token input = parse
     { emit input (`Modules modules) }
 
   | (reference_start as start) ([^ '}']* as target) '}'
-    { emit input (reference_token start target) }
-
+    { 
+      let token = (reference_token start target) in
+      if String.contains target '{' then
+        warning
+          input
+          ~start_offset:(Lexing.lexeme_start lexbuf)
+          (Parse_error.not_allowed
+            ~what:(Token.describe (`Word {|{|}))
+            ~in_what:(Token.describe token));
+      emit input token}
   | "{["
     { code_block (Lexing.lexeme_start lexbuf) None input lexbuf }
 

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -31,7 +31,7 @@ type math_kind =
   Inline | Block
 
 let math_constr kind x =
-  match kind with 
+  match kind with
   | Inline -> `Math_span x
   | Block -> `Math_block x
 
@@ -271,40 +271,61 @@ let raw_markup_target =
 let language_tag_char =
   ['a'-'z' 'A'-'Z' '0'-'9' '_' '-' ]
 
-rule reference_paren_content input start depth buffer = parse 
+rule reference_paren_content input start depth_paren depth_curly buffer = parse
   | '('
     {
       Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
-       reference_paren_content input start (depth + 1) buffer lexbuf }
-  | ')'
-    { 
+       reference_paren_content input start (depth_paren + 1) depth_curly buffer
+        lexbuf }
+  | '{'
+    {
       Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
-      if depth = 0 then
-        ()
+       reference_paren_content input start depth_paren (depth_curly + 1) buffer
+        lexbuf }
+  | ')'
+    {
+      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      if depth_paren = 0 then ()
       else
-        ( reference_paren_content input start (depth  - 1) buffer lexbuf ) }
-  | eof 
+        ( reference_paren_content input start (depth_paren - 1) depth_curly
+            buffer lexbuf ) }
+  | '}'
+    {
+      Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
+      if depth_curly = 0 then
+        warning
+          input
+          ~start_offset:(Lexing.lexeme_end lexbuf)
+          (Parse_error.not_allowed
+            ~what:"'}' (end of reference)"
+            ~in_what:(
+              Printf.sprintf "'%s' (custom operator)"
+                (Buffer.sub buffer 0 ((Buffer.length buffer) - 1))))
+      else
+        ( reference_paren_content input start depth_paren (depth_curly - 1)
+            buffer lexbuf ) }
+  | eof
     { warning
         input
         ~start_offset:(Lexing.lexeme_end lexbuf)
         (Parse_error.not_allowed
           ~what:(Token.describe `End)
-          ~in_what:(Token.describe (reference_token start ""))) 
+          ~in_what:(Token.describe (reference_token start "")))
     }
   | _
-    { 
+    {
       Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
-      reference_paren_content input start depth buffer lexbuf }
+      reference_paren_content input start depth_paren depth_curly buffer lexbuf }
 
 and reference_content input start buffer = parse
-  | '}' 
+  | '}'
     {
       Buffer.contents buffer
     }
   | '('
     {
       Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
-      ((reference_paren_content input start 0 buffer lexbuf)) ;
+      ((reference_paren_content input start 0 0 buffer lexbuf)) ;
       reference_content input start buffer lexbuf
     }
   | '"' [^ '"']* '"'
@@ -312,7 +333,7 @@ and reference_content input start buffer = parse
       Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
       reference_content input start buffer lexbuf
     }
-  | eof 
+  | eof
     { warning
         input
         ~start_offset:(Lexing.lexeme_end lexbuf)
@@ -321,7 +342,7 @@ and reference_content input start buffer = parse
           ~in_what:(Token.describe (reference_token start "")));
         Buffer.contents buffer }
   | _
-    { 
+    {
       Buffer.add_string buffer (Lexing.lexeme lexbuf) ;
       reference_content input start buffer lexbuf }
 
@@ -364,13 +385,13 @@ and token input = parse
 
   | "{e"
     { emit input (`Begin_style `Emphasis) }
-  
+
   | "{L"
     { emit input (`Begin_paragraph_style `Left) }
-  
+
   | "{C"
     { emit input (`Begin_paragraph_style  `Center) }
-  
+
   | "{R"
     { emit input (`Begin_paragraph_style  `Right) }
 
@@ -379,19 +400,19 @@ and token input = parse
 
   | "{_"
     { emit input (`Begin_style `Subscript) }
-  
+
   | "{math" space_char
     { math Block (Buffer.create 1024) 0 (Lexing.lexeme_start lexbuf) input lexbuf }
-    
+
   | "{m" horizontal_space
     { math Inline (Buffer.create 1024) 0 (Lexing.lexeme_start lexbuf) input lexbuf }
-    
+
 
   | "{!modules:" ([^ '}']* as modules) '}'
     { emit input (`Modules modules) }
 
   | (reference_start as start)
-    { 
+    {
       let start_offset = Lexing.lexeme_start lexbuf in
       let target = reference_content input start (Buffer.create 16) lexbuf in
       let token = (reference_token start target) in

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -288,13 +288,13 @@ rule reference_paren_content input start depth_paren depth_curly buffer = parse
   | ')'
     {
       buffer_add_lexeme buffer lexbuf ;
-      if depth_paren = 0 then false
+      if depth_paren = 0 then
+        reference_content input start buffer lexbuf
       else
-        ( reference_paren_content input start (depth_paren - 1) depth_curly
-            buffer lexbuf ) }
+        reference_paren_content input start (depth_paren - 1) depth_curly
+            buffer lexbuf }
   | '}'
     {
-      buffer_add_lexeme buffer lexbuf ;
       if depth_curly = 0 then (
         warning
           input
@@ -303,13 +303,15 @@ rule reference_paren_content input start depth_paren depth_curly buffer = parse
             ~what:"'}' (end of reference)"
             ~in_what:(
               Printf.sprintf "'%s' (custom operator)"
-                (Buffer.sub buffer 0 ((Buffer.length buffer) - 1)))) ;
-        true )
+                (Buffer.contents buffer ))) ;
+        Buffer.contents buffer )
       else
-        ( reference_paren_content input start depth_paren (depth_curly - 1)
+        (
+          buffer_add_lexeme buffer lexbuf ;
+          reference_paren_content input start depth_paren (depth_curly - 1)
             buffer lexbuf ) }
   | eof
-    { false }
+    { reference_content input start buffer lexbuf }
   | _
     {
       buffer_add_lexeme buffer lexbuf ;
@@ -323,11 +325,7 @@ and reference_content input start buffer = parse
   | '('
     {
       buffer_add_lexeme buffer lexbuf ;
-      let ref_closed = reference_paren_content input start 0 0 buffer lexbuf in
-      if ref_closed then
-        Buffer.contents buffer
-      else
-        reference_content input start buffer lexbuf
+      reference_paren_content input start 0 0 buffer lexbuf
     }
   | '"' [^ '"']* '"'
     {

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -274,50 +274,35 @@ let raw_markup_target =
 let language_tag_char =
   ['a'-'z' 'A'-'Z' '0'-'9' '_' '-' ]
 
-rule reference_paren_content input start depth_paren depth_curly buffer = parse
+rule reference_paren_content input start ref_offset start_offset depth_paren
+  buffer =
+  parse
   | '('
     {
       buffer_add_lexeme buffer lexbuf ;
-      reference_paren_content input start (depth_paren + 1) depth_curly buffer
-        lexbuf }
-  | '{'
-    {
-      buffer_add_lexeme buffer lexbuf ;
-       reference_paren_content input start depth_paren (depth_curly + 1) buffer
-        lexbuf }
+      reference_paren_content input start ref_offset start_offset
+        (depth_paren + 1) buffer lexbuf }
   | ')'
     {
       buffer_add_lexeme buffer lexbuf ;
       if depth_paren = 0 then
-        reference_content input start buffer lexbuf
+        reference_content input start ref_offset buffer lexbuf
       else
-        reference_paren_content input start (depth_paren - 1) depth_curly
-            buffer lexbuf }
-  | '}'
-    {
-      if depth_curly = 0 then (
-        warning
-          input
-          ~start_offset:(Lexing.lexeme_end lexbuf)
-          (Parse_error.not_allowed
-            ~what:"'}' (end of reference)"
-            ~in_what:(
-              Printf.sprintf "'%s' (custom operator)"
-                (Buffer.contents buffer ))) ;
-        Buffer.contents buffer )
-      else
-        (
-          buffer_add_lexeme buffer lexbuf ;
-          reference_paren_content input start depth_paren (depth_curly - 1)
-            buffer lexbuf ) }
+        reference_paren_content input start ref_offset start_offset
+          (depth_paren - 1) buffer lexbuf }
   | eof
-    { reference_content input start buffer lexbuf }
+    { warning
+        input
+        ~start_offset
+        (Parse_error.unclosed_bracket ~bracket:"(") ;
+      Buffer.contents buffer }
   | _
     {
       buffer_add_lexeme buffer lexbuf ;
-      reference_paren_content input start depth_paren depth_curly buffer lexbuf }
+      reference_paren_content input start ref_offset start_offset depth_paren
+        buffer lexbuf }
 
-and reference_content input start buffer = parse
+and reference_content input start start_offset buffer = parse
   | '}'
     {
       Buffer.contents buffer
@@ -325,25 +310,24 @@ and reference_content input start buffer = parse
   | '('
     {
       buffer_add_lexeme buffer lexbuf ;
-      reference_paren_content input start 0 0 buffer lexbuf
+      reference_paren_content input start start_offset
+        (Lexing.lexeme_start lexbuf) 0 buffer lexbuf
     }
   | '"' [^ '"']* '"'
     {
       buffer_add_lexeme buffer lexbuf ;
-      reference_content input start buffer lexbuf
+      reference_content input start start_offset buffer lexbuf
     }
   | eof
     { warning
         input
-        ~start_offset:(Lexing.lexeme_end lexbuf)
-        (Parse_error.not_allowed
-          ~what:(Token.describe `End)
-          ~in_what:(Token.describe (reference_token start "")));
-        Buffer.contents buffer }
+        ~start_offset
+        (Parse_error.unclosed_bracket ~bracket:start) ;
+      Buffer.contents buffer }
   | _
     {
       buffer_add_lexeme buffer lexbuf ;
-      reference_content input start buffer lexbuf }
+      reference_content input start start_offset buffer lexbuf }
 
 and token input = parse
   | horizontal_space* eof
@@ -413,7 +397,9 @@ and token input = parse
   | (reference_start as start)
     {
       let start_offset = Lexing.lexeme_start lexbuf in
-      let target = reference_content input start (Buffer.create 16) lexbuf in
+      let target =
+        reference_content input start start_offset (Buffer.create 16) lexbuf
+      in
       let token = (reference_token start target) in
       emit ~start_offset input token }
 

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -278,7 +278,7 @@ rule reference_paren_content input start depth_paren depth_curly buffer = parse
   | '('
     {
       buffer_add_lexeme buffer lexbuf ;
-       reference_paren_content input start (depth_paren + 1) depth_curly buffer
+      reference_paren_content input start (depth_paren + 1) depth_curly buffer
         lexbuf }
   | '{'
     {
@@ -288,14 +288,14 @@ rule reference_paren_content input start depth_paren depth_curly buffer = parse
   | ')'
     {
       buffer_add_lexeme buffer lexbuf ;
-      if depth_paren = 0 then ()
+      if depth_paren = 0 then false
       else
         ( reference_paren_content input start (depth_paren - 1) depth_curly
             buffer lexbuf ) }
   | '}'
     {
       buffer_add_lexeme buffer lexbuf ;
-      if depth_curly = 0 then
+      if depth_curly = 0 then (
         warning
           input
           ~start_offset:(Lexing.lexeme_end lexbuf)
@@ -303,18 +303,13 @@ rule reference_paren_content input start depth_paren depth_curly buffer = parse
             ~what:"'}' (end of reference)"
             ~in_what:(
               Printf.sprintf "'%s' (custom operator)"
-                (Buffer.sub buffer 0 ((Buffer.length buffer) - 1))))
+                (Buffer.sub buffer 0 ((Buffer.length buffer) - 1)))) ;
+        true )
       else
         ( reference_paren_content input start depth_paren (depth_curly - 1)
             buffer lexbuf ) }
   | eof
-    { warning
-        input
-        ~start_offset:(Lexing.lexeme_end lexbuf)
-        (Parse_error.not_allowed
-          ~what:(Token.describe `End)
-          ~in_what:(Token.describe (reference_token start "")))
-    }
+    { false }
   | _
     {
       buffer_add_lexeme buffer lexbuf ;
@@ -328,8 +323,11 @@ and reference_content input start buffer = parse
   | '('
     {
       buffer_add_lexeme buffer lexbuf ;
-      ((reference_paren_content input start 0 0 buffer lexbuf)) ;
-      reference_content input start buffer lexbuf
+      let ref_closed = reference_paren_content input start 0 0 buffer lexbuf in
+      if ref_closed then
+        Buffer.contents buffer
+      else
+        reference_content input start buffer lexbuf
     }
   | '"' [^ '"']* '"'
     {

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -345,9 +345,9 @@ rule token input = parse
           input
           ~start_offset:(Lexing.lexeme_start lexbuf)
           (Parse_error.not_allowed
-            ~what:(Token.describe (`Word {|{|}))
+            ~what:(Token.describe (`Word "{"))
             ~in_what:(Token.describe token));
-      emit input token}
+      emit input token }
   | "{["
     { code_block (Lexing.lexeme_start lexbuf) None input lexbuf }
 

--- a/src/parse_error.ml
+++ b/src/parse_error.ml
@@ -30,6 +30,11 @@ let not_allowed :
   Warning.make ?suggestion "%s is not allowed in %s." (capitalize_ascii what)
     in_what
 
+let unclosed_bracket :
+    ?suggestion:string -> bracket:string -> Loc.span -> Warning.t =
+ fun ?suggestion ~bracket ->
+  Warning.make ?suggestion "Open bracket '%s' is never closed." bracket
+
 let no_leading_whitespace_in_verbatim : Loc.span -> Warning.t =
   Warning.make "'{v' should be followed by whitespace."
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -1632,6 +1632,7 @@ let%expect_test _ =
             (paragraph
              (((f.ml (1 0) (1 9)) (simple ((f.ml (1 2) (1 9)) "(.*{})") ())))))))
          (warnings ())) |}]
+
     let quotes_with_dash =
       test "{!\"my-name\"}";
       [%expect
@@ -1659,13 +1660,15 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (1 8))
             (paragraph
-             (((f.ml (1 0) (1 8)) (simple ((f.ml (1 2) (1 8)) "(.*()}") ())))))))
+             (((f.ml (1 0) (1 8)) (simple ((f.ml (1 2) (1 8)) "(.*()") ())))))))
          (warnings
           ( "File \"f.ml\", line 1, characters 8-8:\
            \n'}' (end of reference) is not allowed in '(.*()' (custom operator)."))) |}]
+
     let operator_eof =
-        test "{!(.*()" ;
-        [%expect {|
+      test "{!(.*()";
+      [%expect
+        {|
           ((output
             (((f.ml (1 0) (1 7))
               (paragraph

--- a/test/test.ml
+++ b/test/test.ml
@@ -1622,6 +1622,16 @@ let%expect_test _ =
             (paragraph
              (((f.ml (1 0) (1 8)) (simple ((f.ml (1 2) (1 8)) "(>::)") ())))))))
          (warnings ())) |}]
+         
+    let operator_with_curly_braces =
+      test "{!(.*{})}";
+      [%expect 
+        {|
+        ((output
+          (((f.ml (1 0) (1 9))
+            (paragraph
+             (((f.ml (1 0) (1 9)) (simple ((f.ml (1 2) (1 9)) "(.*{})") ())))))))
+         (warnings ())) |}]
   end in
   ()
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -1470,8 +1470,8 @@ let%expect_test _ =
           (((f.ml (1 0) (1 5))
             (paragraph (((f.ml (1 0) (1 5)) (simple ((f.ml (1 2) (1 5)) foo) ())))))))
          (warnings
-          ( "File \"f.ml\", line 1, characters 5-5:\
-           \nEnd of text is not allowed in '{!...}' (cross-reference)."))) |}]
+          ( "File \"f.ml\", line 1, characters 0-5:\
+           \nOpen bracket '{!' is never closed."))) |}]
 
     let empty_kind =
       test "{!:foo}";
@@ -1580,8 +1580,8 @@ let%expect_test _ =
             (paragraph
              (((f.ml (1 0) (1 9)) (simple ((f.ml (1 2) (1 9)) val:foo) ())))))))
          (warnings
-          ( "File \"f.ml\", line 1, characters 9-9:\
-           \nEnd of text is not allowed in '{!...}' (cross-reference)."))) |}]
+          ( "File \"f.ml\", line 1, characters 0-9:\
+           \nOpen bracket '{!' is never closed."))) |}]
 
     let operator =
       test "{!(>>=)}";
@@ -1653,6 +1653,16 @@ let%expect_test _ =
                 (((f.ml (1 0) (1 6)) (simple ((f.ml (1 2) (1 6)) "\"}\"") ())))))))
             (warnings ())) |}]
 
+    let operator_with_curly_braces =
+      test "{!( } )}";
+      [%expect
+        {|
+          ((output
+            (((f.ml (1 0) (1 8))
+              (paragraph
+               (((f.ml (1 0) (1 8)) (simple ((f.ml (1 2) (1 8)) "( } )") ())))))))
+           (warnings ())) |}]
+
     let operator_unbalanced =
       test "{!(.*()}";
       [%expect
@@ -1660,10 +1670,10 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (1 8))
             (paragraph
-             (((f.ml (1 0) (1 8)) (simple ((f.ml (1 2) (1 8)) "(.*()") ())))))))
+             (((f.ml (1 0) (1 8)) (simple ((f.ml (1 2) (1 8)) "(.*()}") ())))))))
          (warnings
-          ( "File \"f.ml\", line 1, characters 8-8:\
-           \n'}' (end of reference) is not allowed in '(.*()' (custom operator)."))) |}]
+          ( "File \"f.ml\", line 1, characters 2-8:\
+           \nOpen bracket '(' is never closed."))) |}]
 
     let operator_eof =
       test "{!(.*()";
@@ -1674,8 +1684,8 @@ let%expect_test _ =
               (paragraph
                (((f.ml (1 0) (1 7)) (simple ((f.ml (1 2) (1 7)) "(.*()") ())))))))
            (warnings
-            ( "File \"f.ml\", line 1, characters 7-7:\
-             \nEnd of text is not allowed in '{!...}' (cross-reference)."))) |}]
+            ( "File \"f.ml\", line 1, characters 2-7:\
+             \nOpen bracket '(' is never closed."))) |}]
   end in
   ()
 
@@ -1866,8 +1876,8 @@ let%expect_test _ =
             (paragraph
              (((f.ml (1 0) (1 6)) (with_text ((f.ml (1 3) (1 6)) foo) ())))))))
          (warnings
-          ( "File \"f.ml\", line 1, characters 6-6:\
-           \nEnd of text is not allowed in '{{!...} ...}' (cross-reference)."
+          ( "File \"f.ml\", line 1, characters 0-6:\
+           \nOpen bracket '{{!' is never closed."
             "File \"f.ml\", line 1, characters 6-6:\
            \nEnd of text is not allowed in '{{!...} ...}' (cross-reference)."
             "File \"f.ml\", line 1, characters 0-6:\
@@ -2035,8 +2045,8 @@ let%expect_test _ =
         {|
         ((output (((f.ml (1 0) (1 6)) (paragraph (((f.ml (1 0) (1 6)) (foo ())))))))
          (warnings
-          ( "File \"f.ml\", line 1, characters 6-6:\
-           \nEnd of text is not allowed in '{{:...} ...}' (external link)."
+          ( "File \"f.ml\", line 1, characters 0-6:\
+           \nOpen bracket '{{:' is never closed."
             "File \"f.ml\", line 1, characters 6-6:\
            \nEnd of text is not allowed in '{{:...} ...}' (external link)."))) |}]
 
@@ -2053,8 +2063,8 @@ let%expect_test _ =
         {|
         ((output (((f.ml (1 0) (1 5)) (paragraph (((f.ml (1 0) (1 5)) (foo ())))))))
          (warnings
-          ( "File \"f.ml\", line 1, characters 5-5:\
-           \nEnd of text is not allowed in '{:...} (external link)'."))) |}]
+          ( "File \"f.ml\", line 1, characters 0-5:\
+           \nOpen bracket '{:' is never closed."))) |}]
 
     let empty_single_braces =
       test "{:}";

--- a/test/test.ml
+++ b/test/test.ml
@@ -1650,6 +1650,19 @@ let%expect_test _ =
                (paragraph
                 (((f.ml (1 0) (1 6)) (simple ((f.ml (1 2) (1 6)) "\"}\"") ())))))))
             (warnings ())) |}]
+    let quotes_with_curly_braces =
+      test "{!(.*()}" ;
+      [%expect
+      {|
+        ((output
+          (((f.ml (1 0) (1 8))
+            (paragraph
+             (((f.ml (1 0) (1 8)) (simple ((f.ml (1 2) (1 8)) "(.*()}") ())))))))
+         (warnings
+          ( "File \"f.ml\", line 1, characters 8-8:\
+           \n'}' (end of reference) is not allowed in '(.*()' (custom operator)."
+            "File \"f.ml\", line 1, characters 8-8:\
+           \nEnd of text is not allowed in '{!...}' (cross-reference)."))) |}]
   end in
   ()
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -1632,7 +1632,6 @@ let%expect_test _ =
             (paragraph
              (((f.ml (1 0) (1 9)) (simple ((f.ml (1 2) (1 9)) "(.*{})") ())))))))
          (warnings ())) |}]
-
     let quotes_with_dash =
       test "{!\"my-name\"}";
       [%expect
@@ -1653,7 +1652,7 @@ let%expect_test _ =
                 (((f.ml (1 0) (1 6)) (simple ((f.ml (1 2) (1 6)) "\"}\"") ())))))))
             (warnings ())) |}]
 
-    let quotes_with_curly_braces =
+    let operator_unbalanced =
       test "{!(.*()}";
       [%expect
         {|
@@ -1663,9 +1662,17 @@ let%expect_test _ =
              (((f.ml (1 0) (1 8)) (simple ((f.ml (1 2) (1 8)) "(.*()}") ())))))))
          (warnings
           ( "File \"f.ml\", line 1, characters 8-8:\
-           \n'}' (end of reference) is not allowed in '(.*()' (custom operator)."
-            "File \"f.ml\", line 1, characters 8-8:\
-           \nEnd of text is not allowed in '{!...}' (cross-reference)."))) |}]
+           \n'}' (end of reference) is not allowed in '(.*()' (custom operator)."))) |}]
+    let operator_eof =
+        test "{!(.*()" ;
+        [%expect {|
+          ((output
+            (((f.ml (1 0) (1 7))
+              (paragraph
+               (((f.ml (1 0) (1 7)) (simple ((f.ml (1 2) (1 7)) "(.*()") ())))))))
+           (warnings
+            ( "File \"f.ml\", line 1, characters 7-7:\
+             \nEnd of text is not allowed in '{!...}' (cross-reference)."))) |}]
   end in
   ()
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -1632,6 +1632,7 @@ let%expect_test _ =
             (paragraph
              (((f.ml (1 0) (1 9)) (simple ((f.ml (1 2) (1 9)) "(.*{})") ())))))))
          (warnings ())) |}]
+
     let quotes_with_dash =
       test "{!\"my-name\"}";
       [%expect
@@ -1641,19 +1642,21 @@ let%expect_test _ =
               (paragraph
                (((f.ml (1 0) (1 12)) (simple ((f.ml (1 2) (1 12)) "\"my-name\"") ())))))))
            (warnings ())) |}]
+
     let quotes_with_curly_braces =
       test "{!\"}\"}";
       [%expect
-         {|
+        {|
            ((output
              (((f.ml (1 0) (1 6))
                (paragraph
                 (((f.ml (1 0) (1 6)) (simple ((f.ml (1 2) (1 6)) "\"}\"") ())))))))
             (warnings ())) |}]
+
     let quotes_with_curly_braces =
-      test "{!(.*()}" ;
+      test "{!(.*()}";
       [%expect
-      {|
+        {|
         ((output
           (((f.ml (1 0) (1 8))
             (paragraph

--- a/test/test.ml
+++ b/test/test.ml
@@ -1622,16 +1622,34 @@ let%expect_test _ =
             (paragraph
              (((f.ml (1 0) (1 8)) (simple ((f.ml (1 2) (1 8)) "(>::)") ())))))))
          (warnings ())) |}]
-         
+
     let operator_with_curly_braces =
       test "{!(.*{})}";
-      [%expect 
+      [%expect
         {|
         ((output
           (((f.ml (1 0) (1 9))
             (paragraph
              (((f.ml (1 0) (1 9)) (simple ((f.ml (1 2) (1 9)) "(.*{})") ())))))))
          (warnings ())) |}]
+    let quotes_with_dash =
+      test "{!\"my-name\"}";
+      [%expect
+        {|
+          ((output
+            (((f.ml (1 0) (1 12))
+              (paragraph
+               (((f.ml (1 0) (1 12)) (simple ((f.ml (1 2) (1 12)) "\"my-name\"") ())))))))
+           (warnings ())) |}]
+    let quotes_with_curly_braces =
+      test "{!\"}\"}";
+      [%expect
+         {|
+           ((output
+             (((f.ml (1 0) (1 6))
+               (paragraph
+                (((f.ml (1 0) (1 6)) (simple ((f.ml (1 2) (1 6)) "\"}\"") ())))))))
+            (warnings ())) |}]
   end in
   ()
 


### PR DESCRIPTION
Now custom indexing operators such as `.*{}` can be referenced. 
Edit : braces are also usable in quotes : `{!"}"}` is accepted.