### PR TITLE
Fix light table parsing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup OCaml ${{ matrix.ocaml-version }}
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ matrix.ocaml-version }}
+          ocaml-compiler: ${{ matrix.ocaml-version }}
           opam-local-packages: |
             odoc-parser.opam
 

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -71,8 +71,12 @@ module Table = struct
       loop [] lx
 
     let create ~grid ~align : Ast.table =
-      let to_block x = Loc.at x.Loc.location (`Paragraph [ x ]) in
-      let cell_to_block (x, k) = (List.map to_block x, k) in
+      let cell_to_block (x, k) =
+        let whole_loc = Loc.span (List.map (fun x -> x.Loc.location) x) in
+        match x with
+        | [] -> ([], k)
+        | _ -> ([ Loc.at whole_loc (`Paragraph x) ], k)
+      in
       let row_to_block = List.map cell_to_block in
       let grid_to_block = List.map row_to_block in
       ((grid_to_block grid, align), `Light)

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -1263,7 +1263,7 @@ and light_table ~parent_markup ~parent_markup_location input =
 
 (* Consumes a table row that might start with [`Bar]. *)
 and light_table_row ~parent_markup ~last_loc input =
-  let rec consume_row acc_row acc_cell ~new_line ~last_loc =
+  let rec consume_row acc_row acc_cell acc_space ~new_line ~last_loc =
     let push_cells row cell =
       match cell with [] -> row | _ -> List.rev cell :: row
     in
@@ -1273,16 +1273,17 @@ and light_table_row ~parent_markup ~last_loc input =
     | `Right_brace ->
         junk input;
         (`Stop, return acc_row acc_cell, next_token.location)
-    | `Space _ ->
+    | `Space _ as token ->
         junk input;
-        consume_row acc_row acc_cell ~new_line ~last_loc
+        let i = Loc.at next_token.location token in
+        consume_row acc_row acc_cell (i :: acc_space) ~new_line ~last_loc
     | `Single_newline _ | `Blank_line _ ->
         junk input;
         (`Continue, return acc_row acc_cell, last_loc)
     | `Bar ->
         junk input;
         let acc_row = if new_line then [] else List.rev acc_cell :: acc_row in
-        consume_row acc_row [] ~new_line:false ~last_loc
+        consume_row acc_row [] [] ~new_line:false ~last_loc
     | #token_that_always_begins_an_inline_element as token ->
         let i = inline_element input next_token.location token in
         if Loc.spans_multiple_lines i then
@@ -1291,7 +1292,10 @@ and light_table_row ~parent_markup ~last_loc input =
             ~in_what:(Token.describe `Begin_table_light)
             i.location
           |> add_warning input;
-        consume_row acc_row (i :: acc_cell) ~new_line:false
+        let acc_cell =
+          if acc_cell = [] then [ i ] else (i :: acc_space) @ acc_cell
+        in
+        consume_row acc_row acc_cell [] ~new_line:false
           ~last_loc:next_token.location
     | other_token ->
         Parse_error.not_allowed next_token.location
@@ -1299,9 +1303,9 @@ and light_table_row ~parent_markup ~last_loc input =
           ~in_what:(Token.describe parent_markup)
         |> add_warning input;
         junk input;
-        consume_row acc_row acc_cell ~new_line ~last_loc
+        consume_row acc_row acc_cell acc_space ~new_line ~last_loc
   in
-  consume_row [] [] ~new_line:true ~last_loc
+  consume_row [] [] [] ~new_line:true ~last_loc
 
 (* Consumes a sequence of table rows (starting with '{tr ...}', which are
    represented by [`Begin_table_row] tokens).

--- a/test/test_tables.ml
+++ b/test/test_tables.ml
@@ -484,20 +484,25 @@ let%expect_test _ =
                       (paragraph
                        (((f.ml (3 9) (3 14))
                          (italic (((f.ml (3 12) (3 13)) (word a)))))
+                        ((f.ml (3 14) (3 15)) space)
                         ((f.ml (3 15) (3 28)) (google.com ()))
+                        ((f.ml (3 28) (3 29)) space)
                         ((f.ml (3 29) (3 31)) (word "\\t")))))))
                    (header ())
                    (header
                     (((f.ml (3 36) (3 57))
                       (paragraph
                        (((f.ml (3 36) (3 41)) (math_span b))
+                        ((f.ml (3 41) (3 42)) space)
                         ((f.ml (3 42) (3 47))
                          (emphasis (((f.ml (3 45) (3 46)) (word c)))))
+                        ((f.ml (3 47) (3 48)) space)
                         ((f.ml (3 48) (3 57)) (raw_markup () " xyz ")))))))
                    (header
                     (((f.ml (3 60) (3 71))
                       (paragraph
                        (((f.ml (3 60) (3 65)) (bold (((f.ml (3 63) (3 64)) (word d)))))
+                        ((f.ml (3 65) (3 66)) space)
                         ((f.ml (3 66) (3 71)) (code_span foo)))))))))))
                (align (default default default default))))))
            (warnings ())) |}]
@@ -537,6 +542,7 @@ let%expect_test _ =
                   (((f.ml (5 26) (5 37))
                     (paragraph
                      (((f.ml (5 26) (5 31)) (bold (((f.ml (5 29) (5 30)) (word d)))))
+                      ((f.ml (5 31) (5 32)) space)
                       ((f.ml (5 32) (5 37)) (code_span foo)))))))))))
              (align (default default))))))
          (warnings
@@ -766,16 +772,19 @@ let%expect_test _ =
                   (((f.ml (3 4) (3 25))
                     (paragraph
                      (((f.ml (3 4) (3 10)) (word Header))
-                      ((f.ml (3 11) (3 14)) (word and))
+                      ((f.ml (3 10) (3 11)) space) ((f.ml (3 11) (3 14)) (word and))
+                      ((f.ml (3 14) (3 15)) space)
                       ((f.ml (3 15) (3 20)) (word other))
+                      ((f.ml (3 20) (3 21)) space)
                       ((f.ml (3 21) (3 25)) (word word)))))))))
                (row
                 ((data
                   (((f.ml (5 4) (5 24))
                     (paragraph
-                     (((f.ml (5 4) (5 8)) (word cell))
-                      ((f.ml (5 9) (5 12)) (word and))
+                     (((f.ml (5 4) (5 8)) (word cell)) ((f.ml (5 8) (5 9)) space)
+                      ((f.ml (5 9) (5 12)) (word and)) ((f.ml (5 12) (5 13)) space)
                       ((f.ml (5 13) (5 18)) (word other))
+                      ((f.ml (5 18) (5 19)) space)
                       ((f.ml (5 19) (5 24)) (word words)))))))))))
              (align (default))))))
          (warnings ())) |}]
@@ -800,14 +809,18 @@ let%expect_test _ =
                   (((f.ml (3 4) (3 21))
                     (paragraph
                      (((f.ml (3 4) (3 10)) (word Header))
+                      ((f.ml (3 10) (3 11)) space)
                       ((f.ml (3 11) (3 16)) (word other))
+                      ((f.ml (3 16) (3 17)) space)
                       ((f.ml (3 17) (3 21)) (word word)))))))))
                (row
                 ((data
                   (((f.ml (5 4) (5 21))
                     (paragraph
                      (((f.ml (5 4) (5 10)) (word Header))
+                      ((f.ml (5 10) (5 11)) space)
                       ((f.ml (5 11) (5 16)) (word other))
+                      ((f.ml (5 16) (5 17)) space)
                       ((f.ml (5 17) (5 21)) (word word)))))))))))
              (align (default))))))
          (warnings ())) |}]

--- a/test/test_tables.ml
+++ b/test/test_tables.ml
@@ -751,5 +751,77 @@ let%expect_test _ =
                   (((f.ml (5 7) (5 8)) (paragraph (((f.ml (5 7) (5 8)) (word x)))))))))))
              (align (default default))))))
          (warnings ())) |}]
+
+    let multiple_word =
+      test
+        {|
+      {t
+  | Header and other word |
+  |-----------------------|
+  | cell and other words  |
+      }
+      |};
+      [%expect
+        {|
+        ((output
+          (((f.ml (2 6) (6 7))
+            (table (syntax light)
+             (grid
+              ((row
+                ((header
+                  (((f.ml (3 4) (3 10))
+                    (paragraph (((f.ml (3 4) (3 10)) (word Header)))))
+                   ((f.ml (3 11) (3 14))
+                    (paragraph (((f.ml (3 11) (3 14)) (word and)))))
+                   ((f.ml (3 15) (3 20))
+                    (paragraph (((f.ml (3 15) (3 20)) (word other)))))
+                   ((f.ml (3 21) (3 25))
+                    (paragraph (((f.ml (3 21) (3 25)) (word word)))))))))
+               (row
+                ((data
+                  (((f.ml (5 4) (5 8))
+                    (paragraph (((f.ml (5 4) (5 8)) (word cell)))))
+                   ((f.ml (5 9) (5 12))
+                    (paragraph (((f.ml (5 9) (5 12)) (word and)))))
+                   ((f.ml (5 13) (5 18))
+                    (paragraph (((f.ml (5 13) (5 18)) (word other)))))
+                   ((f.ml (5 19) (5 24))
+                    (paragraph (((f.ml (5 19) (5 24)) (word words)))))))))))
+             (align (default))))))
+         (warnings ())) |}]
+
+    let multiple_word_header =
+      test
+        {|
+      {t
+  | Header other word |
+  |-------------------|
+  | Header other word |
+      }
+      |};
+      [%expect
+        {|
+        ((output
+          (((f.ml (2 6) (6 7))
+            (table (syntax light)
+             (grid
+              ((row
+                ((header
+                  (((f.ml (3 4) (3 10))
+                    (paragraph (((f.ml (3 4) (3 10)) (word Header)))))
+                   ((f.ml (3 11) (3 16))
+                    (paragraph (((f.ml (3 11) (3 16)) (word other)))))
+                   ((f.ml (3 17) (3 21))
+                    (paragraph (((f.ml (3 17) (3 21)) (word word)))))))))
+               (row
+                ((data
+                  (((f.ml (5 4) (5 10))
+                    (paragraph (((f.ml (5 4) (5 10)) (word Header)))))
+                   ((f.ml (5 11) (5 16))
+                    (paragraph (((f.ml (5 11) (5 16)) (word other)))))
+                   ((f.ml (5 17) (5 21))
+                    (paragraph (((f.ml (5 17) (5 21)) (word word)))))))))))
+             (align (default))))))
+         (warnings ())) |}]
   end in
   ()

--- a/test/test_tables.ml
+++ b/test/test_tables.ml
@@ -480,30 +480,25 @@ let%expect_test _ =
                (grid
                 ((row
                   ((header
-                    (((f.ml (3 9) (3 14))
+                    (((f.ml (3 9) (3 31))
                       (paragraph
                        (((f.ml (3 9) (3 14))
-                         (italic (((f.ml (3 12) (3 13)) (word a))))))))
-                     ((f.ml (3 15) (3 28))
-                      (paragraph (((f.ml (3 15) (3 28)) (google.com ())))))
-                     ((f.ml (3 29) (3 31))
-                      (paragraph (((f.ml (3 29) (3 31)) (word "\\t")))))))
+                         (italic (((f.ml (3 12) (3 13)) (word a)))))
+                        ((f.ml (3 15) (3 28)) (google.com ()))
+                        ((f.ml (3 29) (3 31)) (word "\\t")))))))
                    (header ())
                    (header
-                    (((f.ml (3 36) (3 41))
-                      (paragraph (((f.ml (3 36) (3 41)) (math_span b)))))
-                     ((f.ml (3 42) (3 47))
+                    (((f.ml (3 36) (3 57))
                       (paragraph
-                       (((f.ml (3 42) (3 47))
-                         (emphasis (((f.ml (3 45) (3 46)) (word c))))))))
-                     ((f.ml (3 48) (3 57))
-                      (paragraph (((f.ml (3 48) (3 57)) (raw_markup () " xyz ")))))))
+                       (((f.ml (3 36) (3 41)) (math_span b))
+                        ((f.ml (3 42) (3 47))
+                         (emphasis (((f.ml (3 45) (3 46)) (word c)))))
+                        ((f.ml (3 48) (3 57)) (raw_markup () " xyz ")))))))
                    (header
-                    (((f.ml (3 60) (3 65))
+                    (((f.ml (3 60) (3 71))
                       (paragraph
-                       (((f.ml (3 60) (3 65)) (bold (((f.ml (3 63) (3 64)) (word d))))))))
-                     ((f.ml (3 66) (3 71))
-                      (paragraph (((f.ml (3 66) (3 71)) (code_span foo)))))))))))
+                       (((f.ml (3 60) (3 65)) (bold (((f.ml (3 63) (3 64)) (word d)))))
+                        ((f.ml (3 66) (3 71)) (code_span foo)))))))))))
                (align (default default default default))))))
            (warnings ())) |}]
 
@@ -539,11 +534,10 @@ let%expect_test _ =
                          ((f.ml (4 18) (5 14)) space)
                          ((f.ml (5 14) (5 22)) (word newlines))))))))))
                  (data
-                  (((f.ml (5 26) (5 31))
+                  (((f.ml (5 26) (5 37))
                     (paragraph
-                     (((f.ml (5 26) (5 31)) (bold (((f.ml (5 29) (5 30)) (word d))))))))
-                   ((f.ml (5 32) (5 37))
-                    (paragraph (((f.ml (5 32) (5 37)) (code_span foo)))))))))))
+                     (((f.ml (5 26) (5 31)) (bold (((f.ml (5 29) (5 30)) (word d)))))
+                      ((f.ml (5 32) (5 37)) (code_span foo)))))))))))
              (align (default default))))))
          (warnings
           ( "File \"f.ml\", line 4, character 11 to line 5, character 23:\
@@ -769,24 +763,20 @@ let%expect_test _ =
              (grid
               ((row
                 ((header
-                  (((f.ml (3 4) (3 10))
-                    (paragraph (((f.ml (3 4) (3 10)) (word Header)))))
-                   ((f.ml (3 11) (3 14))
-                    (paragraph (((f.ml (3 11) (3 14)) (word and)))))
-                   ((f.ml (3 15) (3 20))
-                    (paragraph (((f.ml (3 15) (3 20)) (word other)))))
-                   ((f.ml (3 21) (3 25))
-                    (paragraph (((f.ml (3 21) (3 25)) (word word)))))))))
+                  (((f.ml (3 4) (3 25))
+                    (paragraph
+                     (((f.ml (3 4) (3 10)) (word Header))
+                      ((f.ml (3 11) (3 14)) (word and))
+                      ((f.ml (3 15) (3 20)) (word other))
+                      ((f.ml (3 21) (3 25)) (word word)))))))))
                (row
                 ((data
-                  (((f.ml (5 4) (5 8))
-                    (paragraph (((f.ml (5 4) (5 8)) (word cell)))))
-                   ((f.ml (5 9) (5 12))
-                    (paragraph (((f.ml (5 9) (5 12)) (word and)))))
-                   ((f.ml (5 13) (5 18))
-                    (paragraph (((f.ml (5 13) (5 18)) (word other)))))
-                   ((f.ml (5 19) (5 24))
-                    (paragraph (((f.ml (5 19) (5 24)) (word words)))))))))))
+                  (((f.ml (5 4) (5 24))
+                    (paragraph
+                     (((f.ml (5 4) (5 8)) (word cell))
+                      ((f.ml (5 9) (5 12)) (word and))
+                      ((f.ml (5 13) (5 18)) (word other))
+                      ((f.ml (5 19) (5 24)) (word words)))))))))))
              (align (default))))))
          (warnings ())) |}]
 
@@ -807,20 +797,18 @@ let%expect_test _ =
              (grid
               ((row
                 ((header
-                  (((f.ml (3 4) (3 10))
-                    (paragraph (((f.ml (3 4) (3 10)) (word Header)))))
-                   ((f.ml (3 11) (3 16))
-                    (paragraph (((f.ml (3 11) (3 16)) (word other)))))
-                   ((f.ml (3 17) (3 21))
-                    (paragraph (((f.ml (3 17) (3 21)) (word word)))))))))
+                  (((f.ml (3 4) (3 21))
+                    (paragraph
+                     (((f.ml (3 4) (3 10)) (word Header))
+                      ((f.ml (3 11) (3 16)) (word other))
+                      ((f.ml (3 17) (3 21)) (word word)))))))))
                (row
                 ((data
-                  (((f.ml (5 4) (5 10))
-                    (paragraph (((f.ml (5 4) (5 10)) (word Header)))))
-                   ((f.ml (5 11) (5 16))
-                    (paragraph (((f.ml (5 11) (5 16)) (word other)))))
-                   ((f.ml (5 17) (5 21))
-                    (paragraph (((f.ml (5 17) (5 21)) (word word)))))))))))
+                  (((f.ml (5 4) (5 21))
+                    (paragraph
+                     (((f.ml (5 4) (5 10)) (word Header))
+                      ((f.ml (5 11) (5 16)) (word other))
+                      ((f.ml (5 17) (5 21)) (word word)))))))))))
              (align (default))))))
          (warnings ())) |}]
   end in


### PR DESCRIPTION
Each inline item in a cell of a light syntax was interpreted as a paragraph...

This fixes it by wrapping the whole content of a cell inside a paragraph instead.